### PR TITLE
Fix opentelemetry-exporter-otlp dependency scope to test

### DIFF
--- a/otel-logs-autoconfigure-log4j/pom.xml
+++ b/otel-logs-autoconfigure-log4j/pom.xml
@@ -22,6 +22,7 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-exporter-otlp</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/otel-logs-autoconfigure-logback/pom.xml
+++ b/otel-logs-autoconfigure-logback/pom.xml
@@ -22,6 +22,7 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-exporter-otlp</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
## Summary
- Set `opentelemetry-exporter-otlp` dependency scope to `test` in both `otel-logs-autoconfigure-logback` and `otel-logs-autoconfigure-log4j` modules
- This dependency is only used in integration tests, not in production code

## Test plan
- [x] `./mvnw clean spring-javaformat:apply test` passes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)